### PR TITLE
Mrh dataprovider: add unit test and initial test data

### DIFF
--- a/test/unit/datatypes/dataproviders/test_mrh_dataproviders.py
+++ b/test/unit/datatypes/dataproviders/test_mrh_dataproviders.py
@@ -1,0 +1,46 @@
+"""
+Unit tests for Multiresolution Heatmap (Mrh) DataProviders.
+.. seealso:: galaxy.datatypes.dataproviders.base
+"""
+
+import os.path
+import imp
+import unittest
+
+import logging
+log = logging.getLogger( __name__ )
+
+test_utils = imp.load_source( 'test_utils',
+    os.path.join( os.path.dirname( __file__), '../../unittest_utils/utility.py' ) )
+
+from test_base_dataproviders import BaseTestCase
+from galaxy.datatypes.dataproviders import mrh
+
+TEST_FILE = os.path.join( test_utils.get_galaxy_root(), 'test-data/1.mrh' )
+
+
+class Test_BaseDataProvider( BaseTestCase ):
+    provider_class = mrh.MrhSquareDataProvider
+
+    def test_no_params( self ):
+        with open( TEST_FILE, 'rb' ) as source:
+            provider = self.provider_class( source )
+            data = list( provider )
+            # print 'data: %s' % str( data )
+            self.assertEqual( data, [] )
+
+    def test_small_window( self ):
+        with open( TEST_FILE, 'rb' ) as source:
+            provider = self.provider_class( source,
+                start1=3500000,
+                start2=3500000,
+                window_size=50000,
+                min_resolution=50001,
+                max_resolution=5000
+            )
+            data = list( provider )
+            # print 'len data: %s' % str( len( data ) )
+            self.assertEqual( len( data ), 102 )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Included here are 'test_mrh_dataprovider.py' and 'test-data/1.mrh'. 

test_mrh_dataprovider is a script that will unit-test (in a non-strict sense) the mrh dataprovider at 'datatypes/dataproviders/mrh.py'. You can call it manually via python: 
(from the galaxy root directory) python test/unit/datatypes/dataproviders/test_mrh_dataprovider.py

Each method on the Test class (which I need to fix the name on) is a separate test. Each should use the TEST_FILE (we can't/shouldn't use custom/string-based data since this is a binary format). More info on the unittest module, etc. is out on the web - any source will do at this point.

I included the 'test-data/1.mrh' file just as a start (it's chr19) - you should replace it. Ideally the file would be as small and simple as possible while still having data that would exercise the mrh format's capabilities: something like a test pattern.

Let me know if you see any problems with the commit.